### PR TITLE
feat: allow hash in manifest html urls

### DIFF
--- a/.changeset/brown-panthers-hunt.md
+++ b/.changeset/brown-panthers-hunt.md
@@ -1,0 +1,5 @@
+---
+'@crxjs/vite-plugin': patch
+---
+
+feat: allow hash in manifest html urls

--- a/packages/vite-plugin/src/node/helpers.ts
+++ b/packages/vite-plugin/src/node/helpers.ts
@@ -111,6 +111,7 @@ export function htmlFiles(manifest: ManifestV3): string[] {
   ]
     .flat()
     .filter(isString)
+    .map(s => s.split('#')[0])
     .sort()
   return [...new Set(files)]
 }


### PR DESCRIPTION
I got an issue when trying to merge popup html page & another html page to use same react app entry point and control by react-router HashRouter. The error is
```
Could not resolve entry module (src/index.html#/popup)
```

I made a small change to ignore the hash part during resolving html files.