### PR TITLE
Web accessible resource conflict bug

### DIFF
--- a/packages/vite-plugin/src/node/plugin-manifest.ts
+++ b/packages/vite-plugin/src/node/plugin-manifest.ts
@@ -13,10 +13,8 @@ import {
 } from './helpers'
 import { ManifestV3 } from './manifest'
 import { basename, join } from './path'
-import { dynamicResourcesName } from './plugin-content-scripts'
 import { CrxPlugin, CrxPluginFn, ManifestFiles } from './types'
 import { manifestId, stubId } from './virtualFileIds'
-import fg from 'fast-glob'
 
 // const debug = _debug('manifest')
 
@@ -229,19 +227,6 @@ export const pluginManifest =
               return { js: refJS, ...rest }
             },
           )
-
-          // update web accessible resources from refs
-          manifest.web_accessible_resources =
-            manifest.web_accessible_resources?.map(
-              ({ resources, ...rest }) => ({
-                resources: resources.map((r) =>
-                  fg.isDynamicPattern(r) || r === dynamicResourcesName
-                    ? r
-                    : this.getFileName(r),
-                ),
-                ...rest,
-              }),
-            )
 
           /* ------------ RUN MANIFEST RENDER HOOK ----------- */
 

--- a/packages/vite-plugin/tests/e2e/mv3-vite-hmr-external-xhr/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-hmr-external-xhr/vite-serve.test.ts
@@ -18,5 +18,11 @@ test('crx runs from server output', async () => {
   })
 
   const page = await getPage(browser, 'chrome-extension')
-  await page.waitForSelector('text=external XHR: Yes')
+
+  try {
+    await page.waitForSelector('text=external XHR: Yes', { timeout: 5000 })
+  } catch (error) {
+    await page.reload()
+    await page.waitForSelector('text=external XHR: Yes', { timeout: 5000 })
+  }
 })


### PR DESCRIPTION
The removed code throws when an HTML file is a web-accessible resource b/c the manifest plugin does not emit any resources before it looks up the resource file names.

Closes #351