### PR TITLE
Fix precontroller script

### DIFF
--- a/.changeset/fair-bananas-sleep.md
+++ b/.changeset/fair-bananas-sleep.md
@@ -1,0 +1,5 @@
+---
+'@crxjs/vite-plugin': patch
+---
+
+check service worker on interval from extension page

--- a/packages/vite-plugin/src/client/es/page-precontroller-script.ts
+++ b/packages/vite-plugin/src/client/es/page-precontroller-script.ts
@@ -5,5 +5,6 @@
  * Note: `oncontrollerchange` does not fire in this context, instead the page
  * continuously reloads until the service worker takes over.
  */
-setTimeout(() => location.reload(), 100)
+const id = setInterval(() => location.reload(), 100)
+setTimeout(() => clearInterval(id), 5000)
 export {}

--- a/packages/vite-plugin/tests/mv3/basic-js/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/basic-js/__snapshots__/serve.test.ts.snap
@@ -152,7 +152,8 @@ export { HMRPort };
 `;
 
 exports[`serve fs output: assets/precontroller.js.js 1`] = `
-"setTimeout(() => location.reload(), 100);
+"const id = setInterval(() => location.reload(), 100);
+setTimeout(() => clearInterval(id), 5e3);
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/basic-ts/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/basic-ts/__snapshots__/serve.test.ts.snap
@@ -149,7 +149,8 @@ export { HMRPort };
 `;
 
 exports[`serve fs output: assets/precontroller.js.js 1`] = `
-"setTimeout(() => location.reload(), 100);
+"const id = setInterval(() => location.reload(), 100);
+setTimeout(() => clearInterval(id), 5e3);
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/dynamic-script/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/dynamic-script/__snapshots__/serve.test.ts.snap
@@ -172,7 +172,8 @@ export { HMRPort };
 `;
 
 exports[`serve fs output: assets/precontroller.js.js 1`] = `
-"setTimeout(() => location.reload(), 100);
+"const id = setInterval(() => location.reload(), 100);
+setTimeout(() => clearInterval(id), 5e3);
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/vite-content-script-css-imports-2/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-content-script-css-imports-2/__snapshots__/serve.test.ts.snap
@@ -181,7 +181,8 @@ export { HMRPort };
 `;
 
 exports[`serve fs output: assets/precontroller.js.js 1`] = `
-"setTimeout(() => location.reload(), 100);
+"const id = setInterval(() => location.reload(), 100);
+setTimeout(() => clearInterval(id), 5e3);
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/vite-content-script-css-imports-3/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-content-script-css-imports-3/__snapshots__/serve.test.ts.snap
@@ -183,7 +183,8 @@ export { HMRPort };
 `;
 
 exports[`serve fs output: assets/precontroller.js.js 1`] = `
-"setTimeout(() => location.reload(), 100);
+"const id = setInterval(() => location.reload(), 100);
+setTimeout(() => clearInterval(id), 5e3);
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/vite-content-script-css-imports/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-content-script-css-imports/__snapshots__/serve.test.ts.snap
@@ -145,7 +145,8 @@ export { HMRPort };
 `;
 
 exports[`serve fs output: assets/precontroller.js.js 1`] = `
-"setTimeout(() => location.reload(), 100);
+"const id = setInterval(() => location.reload(), 100);
+setTimeout(() => clearInterval(id), 5e3);
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/vite-declared-script-resources/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-declared-script-resources/__snapshots__/serve.test.ts.snap
@@ -149,7 +149,8 @@ export { HMRPort };
 `;
 
 exports[`serve fs output: assets/precontroller.js.js 1`] = `
-"setTimeout(() => location.reload(), 100);
+"const id = setInterval(() => location.reload(), 100);
+setTimeout(() => clearInterval(id), 5e3);
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/vite-dynamic-script-resources/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-dynamic-script-resources/__snapshots__/serve.test.ts.snap
@@ -166,7 +166,8 @@ export { HMRPort };
 `;
 
 exports[`serve fs output: assets/precontroller.js.js 1`] = `
-"setTimeout(() => location.reload(), 100);
+"const id = setInterval(() => location.reload(), 100);
+setTimeout(() => clearInterval(id), 5e3);
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/vite-react-fast-refresh/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-react-fast-refresh/__snapshots__/serve.test.ts.snap
@@ -163,7 +163,8 @@ export { HMRPort };
 `;
 
 exports[`serve fs output: assets/precontroller.js.js 1`] = `
-"setTimeout(() => location.reload(), 100);
+"const id = setInterval(() => location.reload(), 100);
+setTimeout(() => clearInterval(id), 5e3);
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/vite-self-directive-in-csp/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-self-directive-in-csp/__snapshots__/serve.test.ts.snap
@@ -152,7 +152,8 @@ export { HMRPort };
 `;
 
 exports[`works with 'self' directive: assets/precontroller.js.js 1`] = `
-"setTimeout(() => location.reload(), 100);
+"const id = setInterval(() => location.reload(), 100);
+setTimeout(() => clearInterval(id), 5e3);
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/with-copied-assets/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/with-copied-assets/__snapshots__/serve.test.ts.snap
@@ -148,7 +148,8 @@ export { HMRPort };
 `;
 
 exports[`serve fs output: assets/precontroller.js.js 1`] = `
-"setTimeout(() => location.reload(), 100);
+"const id = setInterval(() => location.reload(), 100);
+setTimeout(() => clearInterval(id), 5e3);
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/with-public-dir/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/with-public-dir/__snapshots__/serve.test.ts.snap
@@ -100,7 +100,8 @@ export { HMRPort };
 `;
 
 exports[`serve fs output: assets/precontroller.js.js 1`] = `
-"setTimeout(() => location.reload(), 100);
+"const id = setInterval(() => location.reload(), 100);
+setTimeout(() => clearInterval(id), 5e3);
 "
 `;
 


### PR DESCRIPTION
Sometimes during development, an extension page will load before the service worker has taken control of fetch, so the extension page will load the placeholder file instead of loading from the development server. When this happens, the precontroller script should reload the page at an interval, stopping after five seconds.