### PR TITLE
Fix precontroller script bug

### DIFF
--- a/.changeset/spotty-snails-pump.md
+++ b/.changeset/spotty-snails-pump.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+Sometimes during development, an extension page may open before the service worker has a chance to control fetch. The HTML file will load from the file system, but the script tag might load from the dev server. This PR adds a precontroller loader plugin to the dev server so that the extension page will reload and the fetch handler will get the real HTML file from the server.

--- a/packages/vite-plugin/src/client/html/precontroller.html
+++ b/packages/vite-plugin/src/client/html/precontroller.html
@@ -11,15 +11,6 @@
       If you see this message, it means the service worker has not loaded fully.
     </p>
 
-    <p>
-      During development, the service worker reroutes HTML requests to the dev
-      server, so this file isn't used unless the extension service worker opens
-      a page immediately after a full extension reload, and before the service
-      worker takes control of fetch (e.g., in the onInstalled event). In that
-      case, this page will continuously reload until the service worker is
-      ready, always less than 100 ms.
-    </p>
-
     <p>This page is never added in production.</p>
   </body>
 </html>

--- a/packages/vite-plugin/tests/mv3/basic-js/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/basic-js/__snapshots__/serve.test.ts.snap
@@ -182,15 +182,6 @@ exports[`serve fs output: src/popup.html 1`] = `
       If you see this message, it means the service worker has not loaded fully.
     </p>
 
-    <p>
-      During development, the service worker reroutes HTML requests to the dev
-      server, so this file isn't used unless the extension service worker opens
-      a page immediately after a full extension reload, and before the service
-      worker takes control of fetch (e.g., in the onInstalled event). In that
-      case, this page will continuously reload until the service worker is
-      ready, always less than 100 ms.
-    </p>
-
     <p>This page is never added in production.</p>
   </body>
 </html>

--- a/packages/vite-plugin/tests/mv3/basic-ts/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/basic-ts/__snapshots__/serve.test.ts.snap
@@ -179,15 +179,6 @@ exports[`serve fs output: src/popup.html 1`] = `
       If you see this message, it means the service worker has not loaded fully.
     </p>
 
-    <p>
-      During development, the service worker reroutes HTML requests to the dev
-      server, so this file isn't used unless the extension service worker opens
-      a page immediately after a full extension reload, and before the service
-      worker takes control of fetch (e.g., in the onInstalled event). In that
-      case, this page will continuously reload until the service worker is
-      ready, always less than 100 ms.
-    </p>
-
     <p>This page is never added in production.</p>
   </body>
 </html>

--- a/packages/vite-plugin/tests/mv3/vite-react-fast-refresh/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-react-fast-refresh/__snapshots__/serve.test.ts.snap
@@ -267,15 +267,6 @@ exports[`serve fs output: src/popup.html 1`] = `
       If you see this message, it means the service worker has not loaded fully.
     </p>
 
-    <p>
-      During development, the service worker reroutes HTML requests to the dev
-      server, so this file isn't used unless the extension service worker opens
-      a page immediately after a full extension reload, and before the service
-      worker takes control of fetch (e.g., in the onInstalled event). In that
-      case, this page will continuously reload until the service worker is
-      ready, always less than 100 ms.
-    </p>
-
     <p>This page is never added in production.</p>
   </body>
 </html>

--- a/packages/vite-plugin/tests/mv3/vite-self-directive-in-csp/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-self-directive-in-csp/__snapshots__/serve.test.ts.snap
@@ -182,15 +182,6 @@ exports[`works with 'self' directive: src/popup.html 1`] = `
       If you see this message, it means the service worker has not loaded fully.
     </p>
 
-    <p>
-      During development, the service worker reroutes HTML requests to the dev
-      server, so this file isn't used unless the extension service worker opens
-      a page immediately after a full extension reload, and before the service
-      worker takes control of fetch (e.g., in the onInstalled event). In that
-      case, this page will continuously reload until the service worker is
-      ready, always less than 100 ms.
-    </p>
-
     <p>This page is never added in production.</p>
   </body>
 </html>

--- a/packages/vite-plugin/tests/mv3/with-public-dir/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/with-public-dir/__snapshots__/serve.test.ts.snap
@@ -144,15 +144,6 @@ exports[`serve fs output: src/popup.html 1`] = `
       If you see this message, it means the service worker has not loaded fully.
     </p>
 
-    <p>
-      During development, the service worker reroutes HTML requests to the dev
-      server, so this file isn't used unless the extension service worker opens
-      a page immediately after a full extension reload, and before the service
-      worker takes control of fetch (e.g., in the onInstalled event). In that
-      case, this page will continuously reload until the service worker is
-      ready, always less than 100 ms.
-    </p>
-
     <p>This page is never added in production.</p>
   </body>
 </html>


### PR DESCRIPTION
Sometimes during development, an extension page may open before the service worker has a chance to control fetch. The HTML file will load from the file system, but the script tag might load from the dev server. This PR adds a precontroller loader plugin to the dev server so that the extension page will reload and the fetch handler will get the real HTML file from the server.